### PR TITLE
Update Gradle to 7.2

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -132,9 +132,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+        url: https://services.gradle.org/distributions/gradle-7.2-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: bf8b869948901d422e9bb7d1fa61da6a6e19411baa7ad6ee929073df85d6365d
+        sha256: f581709a9c35e9cb92e16f585d2c4bc99b2b1a5f85d2badbd3dc6bff59e1e6dd
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -132,9 +132,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-6.3-bin.zip
+        url: https://services.gradle.org/distributions/gradle-7.1.1-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: 038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768
+        sha256: bf8b869948901d422e9bb7d1fa61da6a6e19411baa7ad6ee929073df85d6365d
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle


### PR DESCRIPTION
**Disclaimer:** I am not familiar with the process of creating or maintaining Flatpaks.

---

This pull request updates Gradle to version 7.2. The current version of Gradle included in this extension, 6.3, is incompatible with Java 16.