### PR TITLE
Build with system libharfbuzz

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -69,6 +69,7 @@ modules:
       - --with-giflib=system
       - --with-libpng=system
       - --with-lcms=system
+      - --with-harfbuzz=system
       - --with-stdc++lib=dynamic
       - --with-extra-cxxflags=-O2 -g -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse
       - --with-extra-cflags=-O2 -g -fstack-protector-strong -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse -fpermissive


### PR DESCRIPTION
Building with the system libharfbuzz fixes https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk11/issues/18 (same bug in openjdk11 and 16) and is also what distros like Debian, Fedora and Arch do.

Same merge request for openjdk11: https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk11/pull/19