### PR TITLE
Update to OpenJDK 20 and FreeDesktop runtime 22.08

### DIFF
--- a/0001-Avoid-requiring-pcsc-development-files-at-runtime.patch
+++ b/0001-Avoid-requiring-pcsc-development-files-at-runtime.patch
@@ -15,13 +15,13 @@ index 38fa3da9e..12086acac 100644
 +++ b/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
 @@ -46,8 +46,8 @@ class PlatformPCSC {
  
-     private final static String PROP_NAME = "sun.security.smartcardio.library";
+     private static final String PROP_NAME = "sun.security.smartcardio.library";
  
--    private final static String LIB1 = "/usr/$LIBISA/libpcsclite.so";
--    private final static String LIB2 = "/usr/local/$LIBISA/libpcsclite.so";
-+    private final static String LIB1 = "/usr/$LIBISA/libpcsclite.so.1";
-+    private final static String LIB2 = "/usr/local/$LIBISA/libpcsclite.so.1";
-     private final static String PCSC_FRAMEWORK = "/System/Library/Frameworks/PCSC.framework/Versions/Current/PCSC";
+-    private static final String LIB1 = "/usr/$LIBISA/libpcsclite.so";
+-    private static final String LIB2 = "/usr/local/$LIBISA/libpcsclite.so";
++    private static final String LIB1 = "/usr/$LIBISA/libpcsclite.so.1";
++    private static final String LIB2 = "/usr/local/$LIBISA/libpcsclite.so.1";
+     private static final String PCSC_FRAMEWORK = "/System/Library/Frameworks/PCSC.framework/Versions/Current/PCSC";
  
      PlatformPCSC() {
 -- 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can bundle the JRE with your Flatpak application by adding this SDK extensio
   "id" : "org.example.MyApp",
   "branch" : "1.0",
   "runtime" : "org.freedesktop.Platform",
-  "runtime-version" : "21.08",
+  "runtime-version" : "22.08",
   "sdk" : "org.freedesktop.Sdk",
   "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk" ],
   "modules" : [ {

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# SDK Extension for OpenJDK 19
+# SDK Extension for OpenJDK 20
 
-This extension contains the OpenJDK 19 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
+This extension contains the OpenJDK 20 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
 
-OpenJDK 19 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
+OpenJDK 20 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
 
 For the current LTS version, see the [OpenJDK 17](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk17) extension.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# SDK Extension for OpenJDK 17
+# SDK Extension for OpenJDK 18
 
-This extension contains the OpenJDK 17 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
+This extension contains the OpenJDK 18 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
 
-OpenJDK 17 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
+OpenJDK 18 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
 
 For the current LTS version, see the [OpenJDK 17](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk17) extension.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# SDK Extension for OpenJDK 18
+# SDK Extension for OpenJDK 19
 
-This extension contains the OpenJDK 18 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
+This extension contains the OpenJDK 19 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
 
-OpenJDK 18 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
+OpenJDK 19 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
 
 For the current LTS version, see the [OpenJDK 17](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk17) extension.
 

--- a/extract_cacerts.sh
+++ b/extract_cacerts.sh
@@ -35,8 +35,9 @@ for certificate in $(ls /etc/ssl/certs/*.pem) ; do
 	issuer=$(echo "$cert" | grep '^Issuer' | cut -d' ' -f1 --complement)
 	fprint=$(echo "$cert" | grep 'SHA1:' | cut -d' ' -f3)
 	alias=$(get_alias "$issuer")
-	echo "Adding $fprint ($alias)"
-	$jdk/bin/keytool -importcert -noprompt -alias $alias -storepass changeit -storetype JKS -keystore cacerts -file $certificate
+	echo "Adding $fprint ($alias, $certificate)"
+	${jdk}/bin/keytool -importcert -noprompt -alias "${alias}" -storepass changeit -storetype JKS -keystore cacerts -file "${certificate}" || \
+		${jdk}/bin/keytool -importcert -noprompt -alias "${alias}_1" -storepass changeit -storetype JKS -keystore cacerts -file "${certificate}" # Since there was a certificate that ended up getting the same alias (<filename>.pem versus <filename>_1.pem)
 done
 
 rm $jdk/lib/security/cacerts

--- a/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
@@ -15,4 +15,7 @@
   <url type="bugtracker">https://bugs.openjdk.java.net/</url>
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
+  <releases>
+    <release version="20.0.1+9" date="2023-05-12"/>
+  </releases>
 </component>

--- a/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
@@ -15,7 +15,4 @@
   <url type="bugtracker">https://bugs.openjdk.java.net/</url>
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
-  <releases>
-    <release version="19.0.2+7" date="2023-02-21"/>
-  </releases>
 </component>

--- a/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
@@ -15,4 +15,7 @@
   <url type="bugtracker">https://bugs.openjdk.java.net/</url>
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
+  <releases>
+    <release version="19.0.2+7" date="2023-02-21"/>
+  </releases>
 </component>

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -150,13 +150,13 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.1-bin.zip
         dest-filename: gradle-bin.zip
-        sha512: 3a71684611dda874a51610c717a6f1f896d7453d3829a851943b14a0e81fc0bade1cf3fd01792c3e464af1a13ceae9e0effa380d7b4f2b585edacbf923c51beb
+        sha512: a8cba3cb86cb432dbb05e53dfcd9aad861a5f27cfe2f6908fed675e564b537f35831af634fd2011a9047acb5ea58c13a7b1c2757e15fc6dc0f7e8e2dc208ba6d
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases
-          version-query: map(select(.prerelease == false)) | first | .tag_name | .[1:]
+          version-query: map(select(.prerelease == false)) | first | .name
           url-query: '["https://services.gradle.org/distributions/gradle-" + $version
             + "-bin.zip"][0]'
     build-commands:

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -80,7 +80,7 @@ modules:
       - LOG=info
       - images
     post-install:
-      - (cd $FLATPAK_DEST/jvm && ln -s openjdk-19.0.0 openjdk-19)
+      - (cd $FLATPAK_DEST/jvm && ln -s openjdk-19.* openjdk-19)
     sources:
       - type: archive
         url: https://github.com/openjdk/jdk19u/archive/refs/tags/jdk-19.0.2+7.tar.gz

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -24,23 +24,23 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.2%2B7/OpenJDK19U-jdk_x64_linux_hotspot_19.0.2_7.tar.gz
+        url: https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20%2B36/OpenJDK20U-jdk_x64_linux_hotspot_20_36.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: bc04881cd3b999ede7dd4f3d580518b99990885cb57a165e807e32837b18cc7b4fd3a9320376222507f085b5f4fe88fd69d2b26dd4f8f34c890f000e6b316880
+        sha512: 519b00cab0ae4008292a18c5e1512e35ffcb4808102887a939a943e50e736752a7d109e4c829be68c109321ef5b100c25b9b8212fea3f518dadb9ba928e7f0ed
         x-checker-data:
           type: json
-          url: https://api.adoptium.net/v3/assets/latest/19/hotspot?os=linux&architecture=x64&image_type=jdk
+          url: https://api.adoptium.net/v3/assets/latest/20/hotspot?os=linux&architecture=x64&image_type=jdk
           version-query: .[0].version.semver
           url-query: .[0].binary.package.link
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.2%2B7/OpenJDK19U-jdk_aarch64_linux_hotspot_19.0.2_7.tar.gz
+        url: https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20%2B36/OpenJDK20U-jdk_aarch64_linux_hotspot_20_36.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 2198e2440c40c3517eab680dce34743c26f52629cb3cffc2f5a2b0a8813d637bb3e683a3ca4bc8e30f69579b7ec2bf0bf06f26f1e3e60e0764e464719013cdd5
+        sha512: fe56afa6a4714db798dd3aebcaf9ea8d2722e560568ad3ee9e41499dc72bef8a419a994e5c29b99afc14078edfede95127164eadbaae5ad7e39516cb79e733c5
         x-checker-data:
           type: json
-          url: https://api.adoptium.net/v3/assets/latest/19/hotspot?os=linux&architecture=aarch64&image_type=jdk
+          url: https://api.adoptium.net/v3/assets/latest/20/hotspot?os=linux&architecture=aarch64&image_type=jdk
           version-query: .[0].version.semver
           url-query: .[0].binary.package.link
     build-commands:
@@ -80,16 +80,16 @@ modules:
       - LOG=info
       - images
     post-install:
-      - (cd $FLATPAK_DEST/jvm && ln -s openjdk-19.* openjdk-19)
+      - (cd $FLATPAK_DEST/jvm && ln -s openjdk-20.* openjdk-20)
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk19u/archive/refs/tags/jdk-19.0.2+7.tar.gz
-        sha512: f25f2fe1f835854bfbe0cfabde092aed3b883a5448b30be5a9e5788e79723bf2f6fca9d41383a99dcd980bed04e7f18cfef3d0f3044b245d32b5cb1ff351eefd
+        url: https://github.com/openjdk/jdk20u/archive/refs/tags/jdk-20+36.tar.gz
+        sha512: 033afb453b12125f34f7a27d676d9c5372e40c65cff8fef6a16c8d8f1b652f5f3405f7ee9ec8761fd54c761c32043e1ec53f2414a6b1e78034fa59e8a6391f97
         x-checker-data:
           type: json
-          url: https://api.adoptium.net/v3/assets/latest/19/hotspot?os=linux&architecture=x64&image_type=jdk
+          url: https://api.adoptium.net/v3/assets/latest/20/hotspot?os=linux&architecture=x64&image_type=jdk
           version-query: .[0].version.openjdk_version
-          url-query: '"https://github.com/openjdk/jdk19u/archive/refs/tags/jdk-" +
+          url-query: '"https://github.com/openjdk/jdk20u/archive/refs/tags/jdk-" +
             $version + ".tar.gz"'
           is-main-source: true
       - type: patch
@@ -104,7 +104,7 @@ modules:
       - type: file
         path: extract_cacerts.sh
     build-commands:
-      - ./extract_cacerts.sh $FLATPAK_DEST/jvm/openjdk-19
+      - ./extract_cacerts.sh $FLATPAK_DEST/jvm/openjdk-20
   - name: ant
     buildsystem: simple
     cleanup:
@@ -112,7 +112,7 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.13-bin.tar.gz
+        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.13-bin.tar.gz
         dest-filename: apache-ant-bin.tar.gz
         sha512: de4ac604629e39a86a306f0541adb3775596909ad92feb8b7de759b1b286417db24f557228737c8b902d6abf722d2ce5bb0c3baa3640cbeec3481e15ab1958c9
         x-checker-data:
@@ -131,9 +131,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.1/binaries/apache-maven-3.9.1-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: 1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
+        sha512: d3be5956712d1c2cf7a6e4c3a2db1841aa971c6097c7a67f59493a5873ccf8c8b889cf988e4e9801390a2b1ae5a0669de07673acb090a083232dbd3faf82f3e3
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -150,9 +150,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.0.2-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: 1b6b558be93f29438d3df94b7dfee02e794b94d9aca4611a92cdb79b6b88e909
+        sha512: 3a71684611dda874a51610c717a6f1f896d7453d3829a851943b14a0e81fc0bade1cf3fd01792c3e464af1a13ceae9e0effa380d7b4f2b585edacbf923c51beb
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases
@@ -169,7 +169,7 @@ modules:
       - type: script
         commands:
           - mkdir -p /app/jre/bin
-          - cd /usr/lib/sdk/openjdk/jvm/openjdk-19
+          - cd /usr/lib/sdk/openjdk/jvm/openjdk-20
           - cp -ra conf lib release /app/jre/
           - rm /app/jre/lib/src.zip /app/jre/lib/ct.sym
           - cp -ra bin/{java,keytool,rmiregistry} /app/jre/bin
@@ -177,12 +177,12 @@ modules:
       - type: script
         commands:
           - mkdir -p /app/jdk/
-          - cd /usr/lib/sdk/openjdk/jvm/openjdk-19
+          - cd /usr/lib/sdk/openjdk/jvm/openjdk-20
           - cp -ra bin conf include jmods lib release /app/jdk/
         dest-filename: installjdk.sh
       - type: script
         commands:
-          - export JAVA_HOME=/usr/lib/sdk/openjdk/jvm/openjdk-18
+          - export JAVA_HOME=/usr/lib/sdk/openjdk/jvm/openjdk-20
           - export PATH=$PATH:/usr/lib/sdk/openjdk/bin
         dest-filename: enable.sh
     build-commands:

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -24,9 +24,9 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20%2B36/OpenJDK20U-jdk_x64_linux_hotspot_20_36.tar.gz
+        url: https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20.0.1%2B9/OpenJDK20U-jdk_x64_linux_hotspot_20.0.1_9.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 519b00cab0ae4008292a18c5e1512e35ffcb4808102887a939a943e50e736752a7d109e4c829be68c109321ef5b100c25b9b8212fea3f518dadb9ba928e7f0ed
+        sha512: aebaa6b9c62f18515ddbaff4c6eba730a84ab37b2a996c1bd1dab7fce094cc6925cc17ced820207ceb68ae8b8e34fcea3047f123477bd07f68ac789088decac1
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/20/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -35,9 +35,9 @@ modules:
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20%2B36/OpenJDK20U-jdk_aarch64_linux_hotspot_20_36.tar.gz
+        url: https://github.com/adoptium/temurin20-binaries/releases/download/jdk-20.0.1%2B9/OpenJDK20U-jdk_aarch64_linux_hotspot_20.0.1_9.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: fe56afa6a4714db798dd3aebcaf9ea8d2722e560568ad3ee9e41499dc72bef8a419a994e5c29b99afc14078edfede95127164eadbaae5ad7e39516cb79e733c5
+        sha512: 2bf71265010cda2ad1d770fff9d7e37a81bfd06fdcfb3e0d618ec5ff65f616832b07570eeecd4805aef13bebf1bb01ee26ab175267bbcd0353177ca694fc72de
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/20/hotspot?os=linux&architecture=aarch64&image_type=jdk
@@ -83,8 +83,8 @@ modules:
       - (cd $FLATPAK_DEST/jvm && ln -s openjdk-20.* openjdk-20)
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk20u/archive/refs/tags/jdk-20+36.tar.gz
-        sha512: 033afb453b12125f34f7a27d676d9c5372e40c65cff8fef6a16c8d8f1b652f5f3405f7ee9ec8761fd54c761c32043e1ec53f2414a6b1e78034fa59e8a6391f97
+        url: https://github.com/openjdk/jdk20u/archive/refs/tags/jdk-20.0.1+9.tar.gz
+        sha512: 50b1e9d3936d649cb94c16d7dbcba8288807a6688808536d359a652700e00d3b5bd8169f6bbe1ec501fe25a7f2214db51794b6c9cd5954c4757606ccbf1037f2
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/20/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -131,9 +131,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.1/binaries/apache-maven-3.9.1-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: d3be5956712d1c2cf7a6e4c3a2db1841aa971c6097c7a67f59493a5873ccf8c8b889cf988e4e9801390a2b1ae5a0669de07673acb090a083232dbd3faf82f3e3
+        sha512: 900bdeeeae550d2d2b3920fe0e00e41b0069f32c019d566465015bdd1b3866395cbe016e22d95d25d51d3a5e614af2c83ec9b282d73309f644859bbad08b63db
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -150,9 +150,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.1-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.1.1-bin.zip
         dest-filename: gradle-bin.zip
-        sha512: a8cba3cb86cb432dbb05e53dfcd9aad861a5f27cfe2f6908fed675e564b537f35831af634fd2011a9047acb5ea58c13a7b1c2757e15fc6dc0f7e8e2dc208ba6d
+        sha512: 6983a44106ca8048d17c08d27a51d66c06d162d692e1e0d16d58f1f1b0d82a02c2b43470bd523776a8efd7bd28c1c6ca6345ea0e69e9b853c0506c89f9f7f874
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -1,7 +1,7 @@
 id: org.freedesktop.Sdk.Extension.openjdk
-branch: '21.08'
+branch: '22.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '21.08'
+runtime-version: '22.08'
 build-extension: true
 sdk: org.freedesktop.Sdk
 separate-locales: false
@@ -24,9 +24,9 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19%2B36/OpenJDK19U-jdk_x64_linux_hotspot_19_36.tar.gz
+        url: https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.2%2B7/OpenJDK19U-jdk_x64_linux_hotspot_19.0.2_7.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 21346f2e31b637a4b3e274cf757b3c9d5c62722e8239a68fbcec90cbb1b01cbdff8cd57b22b1dff7140d17d202a8a897b93b393cae85f0c68946389559caf531
+        sha512: bc04881cd3b999ede7dd4f3d580518b99990885cb57a165e807e32837b18cc7b4fd3a9320376222507f085b5f4fe88fd69d2b26dd4f8f34c890f000e6b316880
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/19/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -35,9 +35,9 @@ modules:
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19%2B36/OpenJDK19U-jdk_aarch64_linux_hotspot_19_36.tar.gz
+        url: https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19.0.2%2B7/OpenJDK19U-jdk_aarch64_linux_hotspot_19.0.2_7.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 3ae70dab8d477f0aecf66ffde2feefd32951a48d709c3153f7b8973052b30f5f06653ccf68a8536d35288fe7cc6f387401ab2f09ecdf72383e331aeac1526b4b
+        sha512: 2198e2440c40c3517eab680dce34743c26f52629cb3cffc2f5a2b0a8813d637bb3e683a3ca4bc8e30f69579b7ec2bf0bf06f26f1e3e60e0764e464719013cdd5
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/19/hotspot?os=linux&architecture=aarch64&image_type=jdk
@@ -83,8 +83,8 @@ modules:
       - (cd $FLATPAK_DEST/jvm && ln -s openjdk-19.0.0 openjdk-19)
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk19u/archive/refs/tags/jdk-19+36.tar.gz
-        sha512: f171009cd21afe22924be9954349dc9739d9af3ebc2f9783043b48fd886a61ef28f549b36ba7a6ec8870b7ffdda35f74f40126c78d2ba46d72c21dc185efd548
+        url: https://github.com/openjdk/jdk19u/archive/refs/tags/jdk-19.0.2+7.tar.gz
+        sha512: f25f2fe1f835854bfbe0cfabde092aed3b883a5448b30be5a9e5788e79723bf2f6fca9d41383a99dcd980bed04e7f18cfef3d0f3044b245d32b5cb1ff351eefd
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/19/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -112,9 +112,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.tar.gz
+        url: https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.13-bin.tar.gz
         dest-filename: apache-ant-bin.tar.gz
-        sha512: 2287dc5cfc21043c14e5413f9afb1c87c9f266ec2a9ba2d3bf2285446f6e4ccb59b558bf2e5c57911a05dfa293c7d5c7ad60ac9f744ba11406f4e6f9a27b2403
+        sha512: de4ac604629e39a86a306f0541adb3775596909ad92feb8b7de759b1b286417db24f557228737c8b902d6abf722d2ce5bb0c3baa3640cbeec3481e15ab1958c9
         x-checker-data:
           type: anitya
           project-id: 50
@@ -131,9 +131,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: f790857f3b1f90ae8d16281f902c689e4f136ebe584aba45e4b1fa66c80cba826d3e0e52fdd04ed44b4c66f6d3fe3584a057c26dfcac544a60b301e6d0f91c26
+        sha512: 1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -150,9 +150,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.0.1-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: f6b8596b10cce501591e92f229816aa4046424f3b24d771751b06779d58c8ec4
+        sha256: 1b6b558be93f29438d3df94b7dfee02e794b94d9aca4611a92cdb79b6b88e909
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -97,6 +97,11 @@ modules:
         url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.tar.gz
         dest-filename: apache-ant-bin.tar.gz
         sha512: 2287dc5cfc21043c14e5413f9afb1c87c9f266ec2a9ba2d3bf2285446f6e4ccb59b558bf2e5c57911a05dfa293c7d5c7ad60ac9f744ba11406f4e6f9a27b2403
+        x-checker-data:
+          type: anitya
+          project-id: 50
+          stable-only: true
+          url-template: http://archive.apache.org/dist/ant/binaries/apache-ant-$version-bin.tar.gz
     build-commands:
       - mkdir -p $FLATPAK_DEST/ant
       - tar xf apache-ant-bin.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/ant
@@ -111,6 +116,11 @@ modules:
         url: http://archive.apache.org/dist/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
         sha512: f790857f3b1f90ae8d16281f902c689e4f136ebe584aba45e4b1fa66c80cba826d3e0e52fdd04ed44b4c66f6d3fe3584a057c26dfcac544a60b301e6d0f91c26
+        x-checker-data:
+          type: anitya
+          project-id: 1894
+          stable-only: true
+          url-template: http://archive.apache.org/dist/maven/maven-3/$version/binaries/apache-maven-$version-bin.tar.gz
     build-commands:
       - mkdir -p $FLATPAK_DEST/maven
       - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native --directory=$FLATPAK_DEST/maven
@@ -124,6 +134,11 @@ modules:
         url: https://services.gradle.org/distributions/gradle-7.4.2-bin.zip
         dest-filename: gradle-bin.zip
         sha256: 29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+        x-checker-data:
+          type: json
+          url: "https://api.github.com/repos/gradle/gradle/releases"
+          version-query: 'map(select(.prerelease == false)) | first | .tag_name | .[1:]'
+          url-query: '["https://services.gradle.org/distributions/gradle-" + $version + "-bin.zip"][0]'
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -1,4 +1,3 @@
----
 id: org.freedesktop.Sdk.Extension.openjdk
 branch: '21.08'
 runtime: org.freedesktop.Sdk
@@ -25,18 +24,28 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://fedorapeople.org/~mbooth/bootstrap_jdk/bootstrap-openjdk-17.0.0.0.35-1.rolling.fc33.x86_64.tar.bz2
+        url: https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19%2B36/OpenJDK19U-jdk_x64_linux_hotspot_19_36.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: ff6f8dda48756cef7ddacde2a2919895d4ac36a83046e6ec0d2fe9277a27725dcc5006b2b957dd71f87db2aa674e92434c66545318546e8f1ef7b2270201fec0
+        sha512: 21346f2e31b637a4b3e274cf757b3c9d5c62722e8239a68fbcec90cbb1b01cbdff8cd57b22b1dff7140d17d202a8a897b93b393cae85f0c68946389559caf531
+        x-checker-data:
+          type: json
+          url: https://api.adoptium.net/v3/assets/latest/19/hotspot?os=linux&architecture=x64&image_type=jdk
+          version-query: .[0].version.semver
+          url-query: .[0].binary.package.link
       - type: file
         only-arches:
           - aarch64
-        url: https://fedorapeople.org/~mbooth/bootstrap_jdk/bootstrap-openjdk-17.0.0.0.35-1.rolling.fc33.aarch64.tar.bz2
+        url: https://github.com/adoptium/temurin19-binaries/releases/download/jdk-19%2B36/OpenJDK19U-jdk_aarch64_linux_hotspot_19_36.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: c274acc1c570145eeb3c4e5ff1e8a4f235fe023d503bb0b725ea6d84f1ca52c648b002a553299df5e6103fcfc58cc5543b98814f3ffeb0aa8a320dce7a5e938b
+        sha512: 3ae70dab8d477f0aecf66ffde2feefd32951a48d709c3153f7b8973052b30f5f06653ccf68a8536d35288fe7cc6f387401ab2f09ecdf72383e331aeac1526b4b
+        x-checker-data:
+          type: json
+          url: https://api.adoptium.net/v3/assets/latest/19/hotspot?os=linux&architecture=aarch64&image_type=jdk
+          version-query: .[0].version.semver
+          url-query: .[0].binary.package.link
     build-commands:
       - mkdir -p $FLATPAK_DEST/bootstrap-java
-      - tar xf java-openjdk.tar.bz2 --strip-components=4 --directory=$FLATPAK_DEST/bootstrap-java
+      - tar xf java-openjdk.tar.bz2 --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java
   - name: java
     buildsystem: autotools
     no-parallel-make: true
@@ -60,8 +69,10 @@ modules:
       - --with-lcms=system
       - --with-harfbuzz=system
       - --with-stdc++lib=dynamic
-      - --with-extra-cxxflags=-grecord-gcc-switches -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fasynchronous-unwind-tables -fstack-clash-protection
-      - --with-extra-cflags=-grecord-gcc-switches -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fasynchronous-unwind-tables -fstack-clash-protection
+      - --with-extra-cxxflags=-grecord-gcc-switches -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS
+        -fstack-protector-strong -fasynchronous-unwind-tables -fstack-clash-protection
+      - --with-extra-cflags=-grecord-gcc-switches -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS
+        -fstack-protector-strong -fasynchronous-unwind-tables -fstack-clash-protection
       - --with-extra-ldflags=-Wl,-z,relro -Wl,-z,now -Wl,--as-needed
       - --disable-javac-server
       - --disable-warnings-as-errors
@@ -69,11 +80,18 @@ modules:
       - LOG=info
       - images
     post-install:
-      - (cd $FLATPAK_DEST/jvm && ln -s openjdk-18.0.1.1 openjdk-18)
+      - (cd $FLATPAK_DEST/jvm && ln -s openjdk-19.0.0 openjdk-19)
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk18u/archive/refs/tags/jdk-18.0.1.1+2.tar.gz
-        sha512: 3d747f585c790227fb095ecb0d21b6a0e02ab9cceac2fc5b31078757a50492ff37c149bfe6655bc00f190cc68af600d1f6aeb18a94b4a08638682c57b83c7622
+        url: https://github.com/openjdk/jdk19u/archive/refs/tags/jdk-19+36.tar.gz
+        sha512: f171009cd21afe22924be9954349dc9739d9af3ebc2f9783043b48fd886a61ef28f549b36ba7a6ec8870b7ffdda35f74f40126c78d2ba46d72c21dc185efd548
+        x-checker-data:
+          type: json
+          url: https://api.adoptium.net/v3/assets/latest/19/hotspot?os=linux&architecture=x64&image_type=jdk
+          version-query: .[0].version.openjdk_version
+          url-query: '"https://github.com/openjdk/jdk19u/archive/refs/tags/jdk-" +
+            $version + ".tar.gz"'
+          is-main-source: true
       - type: patch
         path: 0001-Avoid-requiring-pcsc-development-files-at-runtime.patch
       - type: shell
@@ -86,7 +104,7 @@ modules:
       - type: file
         path: extract_cacerts.sh
     build-commands:
-      - ./extract_cacerts.sh $FLATPAK_DEST/jvm/openjdk-18
+      - ./extract_cacerts.sh $FLATPAK_DEST/jvm/openjdk-19
   - name: ant
     buildsystem: simple
     cleanup:
@@ -123,7 +141,8 @@ modules:
           url-template: http://archive.apache.org/dist/maven/maven-3/$version/binaries/apache-maven-$version-bin.tar.gz
     build-commands:
       - mkdir -p $FLATPAK_DEST/maven
-      - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native --directory=$FLATPAK_DEST/maven
+      - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native
+        --directory=$FLATPAK_DEST/maven
       - ln -s $FLATPAK_DEST/maven/bin/mvn $FLATPAK_DEST/maven/bin/mvnDebug $FLATPAK_DEST/bin
   - name: gradle
     buildsystem: simple
@@ -131,14 +150,15 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+        url: https://services.gradle.org/distributions/gradle-7.5.1-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: 29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
+        sha256: f6b8596b10cce501591e92f229816aa4046424f3b24d771751b06779d58c8ec4
         x-checker-data:
           type: json
-          url: "https://api.github.com/repos/gradle/gradle/releases"
-          version-query: 'map(select(.prerelease == false)) | first | .tag_name | .[1:]'
-          url-query: '["https://services.gradle.org/distributions/gradle-" + $version + "-bin.zip"][0]'
+          url: https://api.github.com/repos/gradle/gradle/releases
+          version-query: map(select(.prerelease == false)) | first | .tag_name | .[1:]
+          url-query: '["https://services.gradle.org/distributions/gradle-" + $version
+            + "-bin.zip"][0]'
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle
@@ -149,7 +169,7 @@ modules:
       - type: script
         commands:
           - mkdir -p /app/jre/bin
-          - cd /usr/lib/sdk/openjdk/jvm/openjdk-18
+          - cd /usr/lib/sdk/openjdk/jvm/openjdk-19
           - cp -ra conf lib release /app/jre/
           - rm /app/jre/lib/src.zip /app/jre/lib/ct.sym
           - cp -ra bin/{java,keytool,rmiregistry} /app/jre/bin
@@ -157,7 +177,7 @@ modules:
       - type: script
         commands:
           - mkdir -p /app/jdk/
-          - cd /usr/lib/sdk/openjdk/jvm/openjdk-18
+          - cd /usr/lib/sdk/openjdk/jvm/openjdk-19
           - cp -ra bin conf include jmods lib release /app/jdk/
         dest-filename: installjdk.sh
       - type: script
@@ -175,4 +195,5 @@ modules:
     build-commands:
       - mkdir -p ${FLATPAK_DEST}/share/metainfo
       - cp org.freedesktop.Sdk.Extension.openjdk.appdata.xml ${FLATPAK_DEST}/share/metainfo
-      - appstream-compose --basename=org.freedesktop.Sdk.Extension.openjdk --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.openjdk
+      - appstream-compose --basename=org.freedesktop.Sdk.Extension.openjdk --prefix=${FLATPAK_DEST}
+        --origin=flatpak org.freedesktop.Sdk.Extension.openjdk

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -25,15 +25,15 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://fedorapeople.org/~mbooth/bootstrap_jdk/bootstrap-openjdk-16.0.1.0.9-1.rolling.fc32.x86_64.tar.bz2
+        url: https://fedorapeople.org/~mbooth/bootstrap_jdk/bootstrap-openjdk-17.0.0.0.35-1.rolling.fc33.x86_64.tar.bz2
         dest-filename: java-openjdk.tar.bz2
-        sha512: 0084f99558a73788438df4fe62700584b41ee962d7de7bd322d8950207c88acfb3839c788def906926325f782ae86068315352dfc3b8c6d5375dec192cf3adeb
+        sha512: ff6f8dda48756cef7ddacde2a2919895d4ac36a83046e6ec0d2fe9277a27725dcc5006b2b957dd71f87db2aa674e92434c66545318546e8f1ef7b2270201fec0
       - type: file
         only-arches:
           - aarch64
-        url: https://fedorapeople.org/~mbooth/bootstrap_jdk/bootstrap-openjdk-16.0.1.0.9-1.rolling.fc32.aarch64.tar.bz2
+        url: https://fedorapeople.org/~mbooth/bootstrap_jdk/bootstrap-openjdk-17.0.0.0.35-1.rolling.fc33.aarch64.tar.bz2
         dest-filename: java-openjdk.tar.bz2
-        sha512: a96e7fc8fdba6bb7a374e2f1f293aca567777b447ae30ac469ef2f38e2704dfa236b54d0d12d66c863f9058d79dd16e5fdffbf22ee1d5d8c7f6e744b3e86e3e4
+        sha512: c274acc1c570145eeb3c4e5ff1e8a4f235fe023d503bb0b725ea6d84f1ca52c648b002a553299df5e6103fcfc58cc5543b98814f3ffeb0aa8a320dce7a5e938b
     build-commands:
       - mkdir -p $FLATPAK_DEST/bootstrap-java
       - tar xf java-openjdk.tar.bz2 --strip-components=4 --directory=$FLATPAK_DEST/bootstrap-java
@@ -43,7 +43,7 @@ modules:
     config-opts:
       - --with-boot-jdk=/usr/lib/sdk/openjdk/bootstrap-java
       - --with-jvm-variants=server
-      - --with-version-build=12
+      - --with-version-build=2
       - --with-version-pre=
       - --with-version-opt=
       - --with-vendor-version-string=21.9
@@ -69,11 +69,11 @@ modules:
       - LOG=info
       - images
     post-install:
-      - (cd $FLATPAK_DEST/jvm && ln -s openjdk-17.0.1 openjdk-17)
+      - (cd $FLATPAK_DEST/jvm && ln -s openjdk-18.0.1.1 openjdk-18)
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk17u/archive/refs/tags/jdk-17.0.1+12.tar.gz
-        sha512: 220d87a29e1a25b670d721c27069b601a48c833069cb252f81ee6de2ff65fef23fd76e689fc755940f7e457b2419ef93a15cbeca64db2a8798028729df876d25
+        url: https://github.com/openjdk/jdk18u/archive/refs/tags/jdk-18.0.1.1+2.tar.gz
+        sha512: 3d747f585c790227fb095ecb0d21b6a0e02ab9cceac2fc5b31078757a50492ff37c149bfe6655bc00f190cc68af600d1f6aeb18a94b4a08638682c57b83c7622
       - type: patch
         path: 0001-Avoid-requiring-pcsc-development-files-at-runtime.patch
       - type: shell
@@ -86,7 +86,7 @@ modules:
       - type: file
         path: extract_cacerts.sh
     build-commands:
-      - ./extract_cacerts.sh $FLATPAK_DEST/jvm/openjdk-17
+      - ./extract_cacerts.sh $FLATPAK_DEST/jvm/openjdk-18
   - name: ant
     buildsystem: simple
     cleanup:
@@ -108,9 +108,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: a9b2d825eacf2e771ed5d6b0e01398589ac1bfa4171f36154d1b5787879605507802f699da6f7cfc80732a5282fd31b28e4cd6052338cbef0fa1358b48a5e3c8
+        sha512: f790857f3b1f90ae8d16281f902c689e4f136ebe584aba45e4b1fa66c80cba826d3e0e52fdd04ed44b4c66f6d3fe3584a057c26dfcac544a60b301e6d0f91c26
     build-commands:
       - mkdir -p $FLATPAK_DEST/maven
       - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native --directory=$FLATPAK_DEST/maven
@@ -121,9 +121,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-7.2-bin.zip
+        url: https://services.gradle.org/distributions/gradle-7.4.2-bin.zip
         dest-filename: gradle-bin.zip
-        sha256: f581709a9c35e9cb92e16f585d2c4bc99b2b1a5f85d2badbd3dc6bff59e1e6dd
+        sha256: 29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle
@@ -134,7 +134,7 @@ modules:
       - type: script
         commands:
           - mkdir -p /app/jre/bin
-          - cd /usr/lib/sdk/openjdk/jvm/openjdk-17
+          - cd /usr/lib/sdk/openjdk/jvm/openjdk-18
           - cp -ra conf lib release /app/jre/
           - rm /app/jre/lib/src.zip /app/jre/lib/ct.sym
           - cp -ra bin/{java,keytool,rmiregistry} /app/jre/bin
@@ -142,12 +142,12 @@ modules:
       - type: script
         commands:
           - mkdir -p /app/jdk/
-          - cd /usr/lib/sdk/openjdk/jvm/openjdk-17
+          - cd /usr/lib/sdk/openjdk/jvm/openjdk-18
           - cp -ra bin conf include jmods lib release /app/jdk/
         dest-filename: installjdk.sh
       - type: script
         commands:
-          - export JAVA_HOME=/usr/lib/sdk/openjdk/jvm/openjdk-17
+          - export JAVA_HOME=/usr/lib/sdk/openjdk/jvm/openjdk-18
           - export PATH=$PATH:/usr/lib/sdk/openjdk/bin
         dest-filename: enable.sh
     build-commands:


### PR DESCRIPTION
Update to OpenJDK 19. This also updates maven to 3.9.0, gradle to 8.0.1, and ant to 1.10.13.

This will fix #13 .

This also adds update checkers for minor revisions (using the [Adoptium API](https://api.adoptium.net/q/swagger-ui/)).