### PR TITLE
Fix OpenJDK 22 Support

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
@@ -17,7 +17,7 @@
   <update_contact>mat.booth@gmail.com</update_contact>
   <releases>
     <release version="jdk-22.0.1+8" date="2024-04-29"/>
-    <release version="jdk-22+36" date="2024-03-20"/>
+    <release version="jdk-22.0.0+36" date="2024-03-20"/>
     <release version="jdk-21.0.3+9" date="2024-04-25"/>
     <release version="jdk-21.0.2+13" date="2024-01-23"/>
     <release version="jdk-21.0.1+12" date="2023-10-27"/>

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -82,7 +82,7 @@ modules:
       - images
     post-install:
       - mkdir -p $FLATPAK_DEST/jvm/ $FLATPAK_DEST/bin
-      - cp -Lr build/linux-x86_64-server-release/images/jdk $FLATPAK_DEST/jvm/openjdk-22
+      - cp -Lr build/linux-*-server-release/images/jdk $FLATPAK_DEST/jvm/openjdk-22
       - ln -s $FLATPAK_DEST/jvm/openjdk-22/bin/* $FLATPAK_DEST/bin
     sources:
       - type: archive

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -48,6 +48,7 @@ modules:
       - tar xf java-openjdk.tar.bz2 --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java
   - name: java
     buildsystem: autotools
+    no-make-install: true
     no-parallel-make: true
     config-opts:
       - --with-boot-jdk=/usr/lib/sdk/openjdk/bootstrap-java

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -81,7 +81,9 @@ modules:
       - LOG=info
       - images
     post-install:
-      - (cd $FLATPAK_DEST/jvm && ln -s openjdk-22.* openjdk-22)
+      - mkdir -p $FLATPAK_DEST/jvm/ $FLATPAK_DEST/bin
+      - cp -Lr build/linux-x86_64-server-release/jdk $FLATPAK_DEST/jvm/openjdk-22
+      - ln -s $FLATPAK_DEST/jvm/openjdk-22/bin/* $FLATPAK_DEST/bin
     sources:
       - type: archive
         url: https://github.com/openjdk/jdk22u/archive/refs/tags/jdk-22.0.1+8.tar.gz

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -129,9 +129,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: 706f01b20dec0305a822ab614d51f32b07ee11d0218175e55450242e49d2156386483b506b3a4e8a03ac8611bae96395fd5eec15f50d3013d5deed6d1ee18224
+        sha512: 7d171def9b85846bf757a2cec94b7529371068a0670df14682447224e57983528e97a6d1b850327e4ca02b139abaab7fcb93c4315119e6f0ffb3f0cbc0d0b9a2
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -148,9 +148,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.7-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.8-bin.zip
         dest-filename: gradle-bin.zip
-        sha512: ddbd320de140634087904c0d0047b146b9697eb0d054a7eada24d6179b65dbeb2189e1c9def463e4788fa1a7f02a720ab9b7bdcdd9bb529770985283d0e51e1a
+        sha512: 8a213e1bdfd65e8c3f191b4d25e04c71d6a2ce9ae75c8d77db72b2248d16104d71db95d4d4caa41d27d45d0207d4db25b6fde38c9cb5e24b28142e9c41c24b74
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -82,7 +82,7 @@ modules:
       - images
     post-install:
       - mkdir -p $FLATPAK_DEST/jvm/ $FLATPAK_DEST/bin
-      - cp -Lr build/linux-x86_64-server-release/jdk $FLATPAK_DEST/jvm/openjdk-22
+      - cp -Lr build/linux-x86_64-server-release/images/jdk $FLATPAK_DEST/jvm/openjdk-22
       - ln -s $FLATPAK_DEST/jvm/openjdk-22/bin/* $FLATPAK_DEST/bin
     sources:
       - type: archive


### PR DESCRIPTION
## Fix OpenJDK 22 so it compiles and runs.
### Changes:
- Updated gradle to 8.8
- Updated maven to 3.9.8
- Re-implemented install process for OpenJDK 22 to replace make install which was removed

Thanks to @hannescam for helping!