### PR TITLE
[branch/25.08] Update to OpenJDK 24 and runtime to 25.08

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Simplified example to make the JRE available at runtime:
 ```yaml
 id: org.example.MyApp
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# SDK Extension for OpenJDK 23
+# SDK Extension for OpenJDK 24
 
-This extension contains the OpenJDK 23 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
+This extension contains the OpenJDK 24 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
 
-OpenJDK 23 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
+OpenJDK 24 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
 
 For the current LTS version, see the [OpenJDK 21](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21) extension.
 
@@ -47,7 +47,7 @@ modules:
   - name: myapp
     buildsystem: simple
     build-options:
-      append-path: /usr/lib/sdk/openjdk/jvm/openjdk-23/bin
+      append-path: /usr/lib/sdk/openjdk/jvm/openjdk-24/bin
     ...
 ```
 

--- a/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
@@ -16,8 +16,11 @@
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
   <releases>
-    <release version="jdk-23.0.2+7" date="2025-01-24">
+    <release version="jdk-24.0.2+12" date="2025-07-25">
       <description></description>
+    </release>
+    <release version="jdk-23.0.2+7" date="2025-01-24">
+      <description/>
     </release>
     <release version="jdk-23.0.1+11" date="2024-10-31">
       <description/>

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -23,23 +23,23 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_x64_linux_hotspot_23.0.2_7.tar.gz
+        url: https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24.0.2%2B12/OpenJDK24U-jdk_x64_linux_hotspot_24.0.2_12.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: cd3f0f1f5ae97286895d1c243a86193fe31791652bd780d5bfc6062b4421f7111da9fe6ae91071a06aa928626ab710693b3cf6b12a6c9b5f1f9e2148b67c9540
+        sha512: 99b8c6f7125e1cb6cd252805f9db7779edf161c4908f7c523d9c6746aa7487f008ce0900bf5244fecfc3a34702201a1b94fd4aaa86cb3958216c4f872d9e824d
         x-checker-data:
           type: json
-          url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=x64&image_type=jdk
+          url: https://api.adoptium.net/v3/assets/latest/24/hotspot?os=linux&architecture=x64&image_type=jdk
           version-query: .[0].version.semver
           url-query: .[0].binary.package.link
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_aarch64_linux_hotspot_23.0.2_7.tar.gz
+        url: https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24.0.2%2B12/OpenJDK24U-jdk_aarch64_linux_hotspot_24.0.2_12.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 70e0a4f040689587da8757821d1ada3b5dc6ac407a336c39f458f91c960f3cb744bb05eb7a6d71885d5d014034c1f5fd5c56c5f2bdd8497e4d22ad353c95afc7
+        sha512: 9de3c9aacccbdfb7b3bb1a400fb2ffc78165291816d8cdea92dad0da6756b38abaf21e09fcdba181a8bd227ee4f87779c22b7e58f8d399f02dc2023a6068cec3
         x-checker-data:
           type: json
-          url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=aarch64&image_type=jdk
+          url: https://api.adoptium.net/v3/assets/latest/24/hotspot?os=linux&architecture=aarch64&image_type=jdk
           version-query: .[0].version.semver
           url-query: .[0].binary.package.link
     build-commands:
@@ -52,10 +52,10 @@ modules:
     config-opts:
       - --with-boot-jdk=/usr/lib/sdk/openjdk/bootstrap-java
       - --with-jvm-variants=server
-      - --with-version-build=7
+      - --with-version-build=12
       - --with-version-pre=
       - --with-version-opt=
-      - --with-vendor-version-string=24.9
+      - --with-vendor-version-string=25.8
       - --with-vendor-name=Flathub
       - --with-vendor-url=https://flathub.org
       - --with-vendor-bug-url=https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk/issues
@@ -81,17 +81,17 @@ modules:
       - images
     post-install:
       - mkdir -p $FLATPAK_DEST/jvm/ $FLATPAK_DEST/bin
-      - cp -Lr build/linux-*-server-release/images/jdk $FLATPAK_DEST/jvm/openjdk-23
-      - ln -s $FLATPAK_DEST/jvm/openjdk-23/bin/* $FLATPAK_DEST/bin
+      - cp -Lr build/linux-*-server-release/images/jdk $FLATPAK_DEST/jvm/openjdk-24
+      - ln -s $FLATPAK_DEST/jvm/openjdk-24/bin/* $FLATPAK_DEST/bin
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk23u/archive/refs/tags/jdk-23.0.2+7.tar.gz
-        sha512: e96abf66cd62c307f71c3a70367a9147e250d84f69c685bfef97f901a5414e1bb10c4702d81238554443b580e654ded41d476643f7649beafa0f3dd98ac4e499
+        url: https://github.com/openjdk/jdk24u/archive/refs/tags/jdk-24.0.2+12.tar.gz
+        sha512: fa3457d69279db37204d829b6637aec541dc76f58574c31b6c7da5cb2758f87d759065cf77e97cded964385887ce9ee859fd81b609efcd490319a774821fe79b
         x-checker-data:
           type: json
-          url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=x64&image_type=jdk
+          url: https://api.adoptium.net/v3/assets/latest/24/hotspot?os=linux&architecture=x64&image_type=jdk
           version-query: .[0].release_name
-          url-query: '"https://github.com/openjdk/jdk23u/archive/refs/tags/" + $version
+          url-query: '"https://github.com/openjdk/jdk24u/archive/refs/tags/" + $version
             + ".tar.gz"'
           is-main-source: true
       - type: shell
@@ -107,7 +107,7 @@ modules:
       - type: file
         path: extract_cacerts.sh
     build-commands:
-      - ./extract_cacerts.sh $FLATPAK_DEST/jvm/openjdk-23
+      - ./extract_cacerts.sh $FLATPAK_DEST/jvm/openjdk-24
   - name: ant
     buildsystem: simple
     cleanup:
@@ -134,9 +134,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
+        sha512: bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -153,9 +153,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+        url: https://services.gradle.org/distributions/gradle-9.0.0-bin.zip
         dest-filename: gradle-bin.zip
-        sha512: 816d90f7af71f83fbf21b1216c4cdbd64814b109815dfef2a0adced19c598877c781e078ec01f86bfbb830b1dee07483642b5872cdf5a380c0c7da0a8a3a884a
+        sha512: 7558c0bd914a2a4fabb12fe92283e197b8cc308292c7c90fb90dc7e9b880b38168c9406272611be30d63860a9143538ee69309c251471d2ab2dfd2238c5904a6
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases
@@ -172,7 +172,7 @@ modules:
       - type: script
         commands:
           - mkdir -p /app/jre/bin
-          - cd /usr/lib/sdk/openjdk/jvm/openjdk-23
+          - cd /usr/lib/sdk/openjdk/jvm/openjdk-24
           - cp -ra conf lib release /app/jre/
           - rm /app/jre/lib/src.zip /app/jre/lib/ct.sym
           - cp -ra bin/{java,keytool,rmiregistry} /app/jre/bin
@@ -180,12 +180,12 @@ modules:
       - type: script
         commands:
           - mkdir -p /app/jdk/
-          - cd /usr/lib/sdk/openjdk/jvm/openjdk-23
+          - cd /usr/lib/sdk/openjdk/jvm/openjdk-24
           - cp -ra bin conf include jmods lib release /app/jdk/
         dest-filename: installjdk.sh
       - type: script
         commands:
-          - export JAVA_HOME=/usr/lib/sdk/openjdk/jvm/openjdk-23
+          - export JAVA_HOME=/usr/lib/sdk/openjdk/jvm/openjdk-24
           - export PATH=$PATH:/usr/lib/sdk/openjdk/bin
         dest-filename: enable.sh
     build-commands:

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -1,7 +1,7 @@
 id: org.freedesktop.Sdk.Extension.openjdk
-branch: '24.08'
+branch: '25.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '24.08'
+runtime-version: '25.08'
 build-extension: true
 sdk: org.freedesktop.Sdk
 separate-locales: false
@@ -101,6 +101,7 @@ modules:
       - type: patch
         paths:
           - patches/0001-Allow-ccache-to-be-handled-by-GCC-wrappers.patch
+          - patches/0002-Build-failure-with-glibc-2.42-due-to-uabs-name.patch
   - name: cacerts
     buildsystem: simple
     sources:

--- a/patches/0002-Build-failure-with-glibc-2.42-due-to-uabs-name.patch
+++ b/patches/0002-Build-failure-with-glibc-2.42-due-to-uabs-name.patch
@@ -1,0 +1,172 @@
+diff --git a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+index 76f88764416..2e1deba2281 100644
+--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
++++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+@@ -457,7 +457,7 @@ void Assembler::bang_stack_with_offset(int offset) { Unimplemented(); }
+ 
+ bool asm_util::operand_valid_for_immediate_bits(int64_t imm, unsigned nbits) {
+   guarantee(nbits == 8 || nbits == 12, "invalid nbits value");
+-  uint64_t uimm = (uint64_t)uabs((jlong)imm);
++  uint64_t uimm = (uint64_t)g_uabs((jlong)imm);
+   if (uimm < (UCONST64(1) << nbits))
+     return true;
+   if (uimm < (UCONST64(1) << (2 * nbits))
+diff --git a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+index a5e0e2665af..1686603b17e 100644
+--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
++++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+@@ -932,7 +932,7 @@ class Assembler : public AbstractAssembler {
+   static const uint64_t branch_range = NOT_DEBUG(128 * M) DEBUG_ONLY(2 * M);
+ 
+   static bool reachable_from_branch_at(address branch, address target) {
+-    return uabs(target - branch) < branch_range;
++    return g_uabs(target - branch) < branch_range;
+   }
+ 
+   // Unconditional branch (immediate)
+diff --git a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+index d561fb912a3..c41919c323d 100644
+--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
++++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+@@ -3271,7 +3271,7 @@ void MacroAssembler::wrap_add_sub_imm_insn(Register Rd, Register Rn, uint64_t im
+   if (fits) {
+     (this->*insn1)(Rd, Rn, imm);
+   } else {
+-    if (uabs(imm) < (1 << 24)) {
++    if (g_uabs(imm) < (1 << 24)) {
+        (this->*insn1)(Rd, Rn, imm & -(1 << 12));
+        (this->*insn1)(Rd, Rd, imm & ((1 << 12)-1));
+     } else {
+diff --git a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+index de5df5c1af1..b521e748bcf 100644
+--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
++++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+@@ -1133,7 +1133,7 @@ class StubGenerator: public StubCodeGenerator {
+ 
+   void copy_memory_small(DecoratorSet decorators, BasicType type, Register s, Register d, Register count, int step) {
+     bool is_backwards = step < 0;
+-    size_t granularity = uabs(step);
++    size_t granularity = g_uabs(step);
+     int direction = is_backwards ? -1 : 1;
+ 
+     Label Lword, Lint, Lshort, Lbyte;
+@@ -1192,7 +1192,7 @@ class StubGenerator: public StubCodeGenerator {
+                    Register s, Register d, Register count, int step) {
+     copy_direction direction = step < 0 ? copy_backwards : copy_forwards;
+     bool is_backwards = step < 0;
+-    unsigned int granularity = uabs(step);
++    unsigned int granularity = g_uabs(step);
+     const Register t0 = r3, t1 = r4;
+ 
+     // <= 80 (or 96 for SIMD) bytes do inline. Direction doesn't matter because we always
+diff --git a/src/hotspot/cpu/riscv/assembler_riscv.hpp b/src/hotspot/cpu/riscv/assembler_riscv.hpp
+index 31713d7362a..0eaa5548779 100644
+--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
++++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
+@@ -3393,7 +3393,7 @@ enum Nf {
+   static const unsigned long branch_range = 1 * M;
+ 
+   static bool reachable_from_branch_at(address branch, address target) {
+-    return uabs(target - branch) < branch_range;
++    return g_uabs(target - branch) < branch_range;
+   }
+ 
+   // Decode the given instruction, checking if it's a 16-bit compressed
+diff --git a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+index 7e6fe50e8f8..54973022c12 100644
+--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
++++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+@@ -874,7 +874,7 @@ class StubGenerator: public StubCodeGenerator {
+ 
+   void copy_memory_v(Register s, Register d, Register count, int step) {
+     bool is_backward = step < 0;
+-    int granularity = uabs(step);
++    int granularity = g_uabs(step);
+ 
+     const Register src = x30, dst = x31, vl = x14, cnt = x15, tmp1 = x16, tmp2 = x17;
+     assert_different_registers(s, d, cnt, vl, tmp1, tmp2);
+@@ -936,7 +936,7 @@ class StubGenerator: public StubCodeGenerator {
+     }
+ 
+     bool is_backwards = step < 0;
+-    int granularity = uabs(step);
++    int granularity = g_uabs(step);
+ 
+     const Register src = x30, dst = x31, cnt = x15, tmp3 = x16, tmp4 = x17, tmp5 = x14, tmp6 = x13;
+     const Register gct1 = x28, gct2 = x29, gct3 = t2;
+diff --git a/src/hotspot/share/opto/mulnode.cpp b/src/hotspot/share/opto/mulnode.cpp
+index ad98fda025f..bf7bf0336c4 100644
+--- a/src/hotspot/share/opto/mulnode.cpp
++++ b/src/hotspot/share/opto/mulnode.cpp
+@@ -245,7 +245,7 @@ Node *MulINode::Ideal(PhaseGVN *phase, bool can_reshape) {
+   // Check for negative constant; if so negate the final result
+   bool sign_flip = false;
+ 
+-  unsigned int abs_con = uabs(con);
++  unsigned int abs_con = g_uabs(con);
+   if (abs_con != (unsigned int)con) {
+     sign_flip = true;
+   }
+@@ -480,7 +480,7 @@ Node *MulLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
+ 
+   // Check for negative constant; if so negate the final result
+   bool sign_flip = false;
+-  julong abs_con = uabs(con);
++  julong abs_con = g_uabs(con);
+   if (abs_con != (julong)con) {
+     sign_flip = true;
+   }
+diff --git a/src/hotspot/share/opto/subnode.cpp b/src/hotspot/share/opto/subnode.cpp
+index 1698ca5338b..f50bb8a93e3 100644
+--- a/src/hotspot/share/opto/subnode.cpp
++++ b/src/hotspot/share/opto/subnode.cpp
+@@ -1927,14 +1927,14 @@ const Type* AbsNode::Value(PhaseGVN* phase) const {
+   case Type::Int: {
+     const TypeInt* ti = t1->is_int();
+     if (ti->is_con()) {
+-      return TypeInt::make(uabs(ti->get_con()));
++      return TypeInt::make(g_uabs(ti->get_con()));
+     }
+     break;
+   }
+   case Type::Long: {
+     const TypeLong* tl = t1->is_long();
+     if (tl->is_con()) {
+-      return TypeLong::make(uabs(tl->get_con()));
++      return TypeLong::make(g_uabs(tl->get_con()));
+     }
+     break;
+   }
+diff --git a/src/hotspot/share/utilities/globalDefinitions.hpp b/src/hotspot/share/utilities/globalDefinitions.hpp
+index ccd3106b471..c5f40792a9d 100644
+--- a/src/hotspot/share/utilities/globalDefinitions.hpp
++++ b/src/hotspot/share/utilities/globalDefinitions.hpp
+@@ -1144,7 +1144,7 @@ inline bool is_even(intx x) { return !is_odd(x); }
+ 
+ // abs methods which cannot overflow and so are well-defined across
+ // the entire domain of integer types.
+-static inline unsigned int uabs(unsigned int n) {
++static inline unsigned int g_uabs(unsigned int n) {
+   union {
+     unsigned int result;
+     int value;
+@@ -1153,7 +1153,7 @@ static inline unsigned int uabs(unsigned int n) {
+   if (value < 0) result = 0-result;
+   return result;
+ }
+-static inline julong uabs(julong n) {
++static inline julong g_uabs(julong n) {
+   union {
+     julong result;
+     jlong value;
+@@ -1162,8 +1162,8 @@ static inline julong uabs(julong n) {
+   if (value < 0) result = 0-result;
+   return result;
+ }
+-static inline julong uabs(jlong n) { return uabs((julong)n); }
+-static inline unsigned int uabs(int n) { return uabs((unsigned int)n); }
++static inline julong g_uabs(jlong n) { return g_uabs((julong)n); }
++static inline unsigned int g_uabs(int n) { return g_uabs((unsigned int)n); }
+ 
+ // "to" should be greater than "from."
+ inline size_t byte_size(void* from, void* to) {


### PR DESCRIPTION
This updates OpenJDK to version 24 and the Freedesktop runtime to version 25.08.

I've rebuilt quite a few apps locally, and briefly tested some of their basic functionality.

These are the apps I tested:

- [OmegaT](https://github.com/flathub/org.omegat.OmegaT)
- [MediathekView](https://github.com/flathub/de.mediathekview.MediathekView)
- [FileBot](https://github.com/flathub/net.filebot.FileBot)
- [Gluon Scene Builder](https://github.com/flathub/com.gluonhq.SceneBuilder)
- [TigerJython](https://github.com/flathub/ch.tigerjython.TigerJython2)
- [KeyStore Explorer](https://github.com/flathub/org.keystore_explorer.KeyStoreExplorer)

Some of them displayed deprecation/security warnings in the terminal, but the features I tested seemed unaffected, so that's good enough for me.

Closes #96