### PR TITLE
[branch/23.08] Patch: Allow ccache to be handled by GCC wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# SDK Extension for OpenJDK 22
+# SDK Extension for OpenJDK 23
 
-This extension contains the OpenJDK 22 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
+This extension contains the OpenJDK 23 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
 
-OpenJDK 22 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
+OpenJDK 23 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
 
 For the current LTS version, see the [OpenJDK 21](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21) extension.
 
@@ -41,3 +41,13 @@ You can bundle the JRE with your Flatpak application by adding this SDK extensio
   ]
 }
 ```
+
+## Developement
+
+### Build and install
+```bash
+flatpak-builder --user --install --force-clean flatpakbuildir org.freedesktop.Sdk.Extension.openjdk.yaml
+```
+### Uninstall
+```bash
+flatpak uninstall --user org.freedesktop.Sdk.Extension.openjdk

--- a/README.md
+++ b/README.md
@@ -15,21 +15,29 @@ You can bundle the JRE with your Flatpak application by adding this SDK extensio
 ```
 {
   "id" : "org.example.MyApp",
-  "branch" : "1.0",
   "runtime" : "org.freedesktop.Platform",
   "runtime-version" : "23.08",
   "sdk" : "org.freedesktop.Sdk",
-  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk" ],
-  "modules" : [ {
-    "name" : "openjdk",
-    "buildsystem" : "simple",
-    "build-commands" : [ "/usr/lib/sdk/openjdk/install.sh" ]
-  }, {
-    "name" : "myapp",
-    "buildsystem" : "simple",
-    ....
-  } ]
+  "sdk-extensions" : [
+    "org.freedesktop.Sdk.Extension.openjdk"
+  ],
+  "modules" : [
+    {
+      "name" : "openjdk",
+      "buildsystem" : "simple",
+      "build-commands" : [
+        "/usr/lib/sdk/openjdk/install.sh"
+      ]
+    },
+    {
+      "name" : "myapp",
+      "buildsystem" : "simple",
+      ....
+    }
+  ]
   ....
-  "finish-args" : [ "--env=PATH=/app/jre/bin:/usr/bin" ]
+  "finish-args" : [
+    "--env=PATH=/app/jre/bin:/app/bin:/usr/bin"
+  ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -10,44 +10,55 @@ For the previous LTS version, see the [OpenJDK 17](https://github.com/flathub/or
 
 ## Usage
 
-You can bundle the JRE with your Flatpak application by adding this SDK extension to your Flatpak manifest and calling the install.sh script. For example:
+You can bundle the JRE with your Flatpak application by adding it to `sdk-extensions` in your Flatpak manifest and executing the `/usr/lib/sdk/openjdk/install.sh` script.
 
-```
-{
-  "id" : "org.example.MyApp",
-  "runtime" : "org.freedesktop.Platform",
-  "runtime-version" : "23.08",
-  "sdk" : "org.freedesktop.Sdk",
-  "sdk-extensions" : [
-    "org.freedesktop.Sdk.Extension.openjdk"
-  ],
-  "modules" : [
-    {
-      "name" : "openjdk",
-      "buildsystem" : "simple",
-      "build-commands" : [
-        "/usr/lib/sdk/openjdk/install.sh"
-      ]
-    },
-    {
-      "name" : "myapp",
-      "buildsystem" : "simple",
-      ....
-    }
-  ]
-  ....
-  "finish-args" : [
-    "--env=PATH=/app/jre/bin:/app/bin:/usr/bin"
-  ]
-}
+Simplified example to make the JRE available at runtime:
+
+```yaml
+id: org.example.MyApp
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk
+
+modules:
+  - name: openjdk
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk/install.sh
+  - name: myapp
+    buildsystem: simple
+    ...
+
+...
+
+finish-args:
+  - --env=PATH=/app/jre/bin:/app/bin:/usr/bin
 ```
 
-## Developement
+To additionally make the JRE available at buildtime of module `myapp`, set `build-options.append-path` accordingly:
+
+```yaml
+...
+
+modules:
+  ...
+  - name: myapp
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/openjdk/jvm/openjdk-23/bin
+    ...
+```
+
+## Development
 
 ### Build and install
+
 ```bash
 flatpak-builder --user --install --force-clean flatpakbuildir org.freedesktop.Sdk.Extension.openjdk.yaml
 ```
 ### Uninstall
+
 ```bash
 flatpak uninstall --user org.freedesktop.Sdk.Extension.openjdk

--- a/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
@@ -16,6 +16,10 @@
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
   <releases>
+    <release version="jdk-23.0.0+37" date="2024-08-21">
+      <url type="details">https://github.com/openjdk/jdk/releases/tag/jdk-23%2B37</url>
+      <description></description>
+    </release>
     <release version="jdk-22.0.2+9" date="2024-07-17">
       <description></description>
     </release>

--- a/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
@@ -16,12 +16,15 @@
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
   <releases>
-    <release version="jdk-23.0.0+37" date="2024-08-21">
-      <url type="details">https://github.com/openjdk/jdk/releases/tag/jdk-23%2B37</url>
+    <release version="jdk-23.0.1+11" date="2024-10-31">
       <description></description>
     </release>
+    <release version="jdk-23.0.0+37" date="2024-08-21">
+      <url type="details">https://github.com/openjdk/jdk/releases/tag/jdk-23%2B37</url>
+      <description/>
+    </release>
     <release version="jdk-22.0.2+9" date="2024-07-17">
-      <description></description>
+      <description/>
     </release>
     <release version="jdk-22.0.1+8" date="2024-04-29"/>
     <release version="jdk-22.0.0+36" date="2024-03-20"/>

--- a/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
@@ -16,8 +16,11 @@
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
   <releases>
-    <release version="jdk-23.0.1+11" date="2024-10-31">
+    <release version="jdk-23.0.2+7" date="2025-01-24">
       <description></description>
+    </release>
+    <release version="jdk-23.0.1+11" date="2024-10-31">
+      <description/>
     </release>
     <release version="jdk-23.0.0+37" date="2024-08-21">
       <url type="details">https://github.com/openjdk/jdk/releases/tag/jdk-23%2B37</url>

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -23,23 +23,23 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_x64_linux_hotspot_22.0.2_9.tar.gz
+        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23%2B37/OpenJDK23U-jdk_x64_linux_hotspot_23_37.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 63279c060903dfdc548b4e8c13822f39bf1fe1951f26f9345e8501eda9a992f9120706a09dc02a8ce48640c118239b8d0aa577a166d5a1422a8e1e6f14f32d74
+        sha512: 99bcd5081a17a533075ccec654d3013f0a212ca33a321c04a9ce95bc51c4094d0d4493b75b30774bffe5c188c419b61d8d6c8fdd62e253f603a93848076ce9b9
         x-checker-data:
           type: json
-          url: https://api.adoptium.net/v3/assets/latest/22/hotspot?os=linux&architecture=x64&image_type=jdk
+          url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=x64&image_type=jdk
           version-query: .[0].version.semver
           url-query: .[0].binary.package.link
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_aarch64_linux_hotspot_22.0.2_9.tar.gz
+        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23%2B37/OpenJDK23U-jdk_aarch64_linux_hotspot_23_37.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: f6db50f3ba1e6a9515685f4cce5221a999ed6b079541824b0ee62d7cc3fec92c8abd3da8f12302fd60975adaced2035d1eb697dcd4830c75d9e722815bf5bbcb
+        sha512: deaff10db582fddad086bb20617206994af78a0bb828e5b15f2d2443f39bcf2bb37fca573654819f23cff8eedb7d9ca7c9e74badf7224cce0d17bd0ba3c35245
         x-checker-data:
           type: json
-          url: https://api.adoptium.net/v3/assets/latest/22/hotspot?os=linux&architecture=aarch64&image_type=jdk
+          url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=aarch64&image_type=jdk
           version-query: .[0].version.semver
           url-query: .[0].binary.package.link
     build-commands:
@@ -52,10 +52,10 @@ modules:
     config-opts:
       - --with-boot-jdk=/usr/lib/sdk/openjdk/bootstrap-java
       - --with-jvm-variants=server
-      - --with-version-build=36
+      - --with-version-build=37
       - --with-version-pre=
       - --with-version-opt=
-      - --with-vendor-version-string=24.3
+      - --with-vendor-version-string=24.9
       - --with-vendor-name=Flathub
       - --with-vendor-url=https://flathub.org
       - --with-vendor-bug-url=https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk/issues
@@ -81,30 +81,30 @@ modules:
       - images
     post-install:
       - mkdir -p $FLATPAK_DEST/jvm/ $FLATPAK_DEST/bin
-      - cp -Lr build/linux-*-server-release/images/jdk $FLATPAK_DEST/jvm/openjdk-22
-      - ln -s $FLATPAK_DEST/jvm/openjdk-22/bin/* $FLATPAK_DEST/bin
+      - cp -Lr build/linux-*-server-release/images/jdk $FLATPAK_DEST/jvm/openjdk-23
+      - ln -s $FLATPAK_DEST/jvm/openjdk-23/bin/* $FLATPAK_DEST/bin
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk22u/archive/refs/tags/jdk-22.0.2+9.tar.gz
-        sha512: 99df868ea802088d3a7aaf4fabfa6e8d70873beafad52040a2a741e132fdb5c9f805185a45ec923807b02fa1819613a0f68b8533cec5dd292e62d340750ede46
+        url: https://github.com/openjdk/jdk/archive/refs/tags/jdk-23+37.tar.gz
+        sha512: 169ea4baec06601ce060eb69d9854ffb664a4a26ce69f35886bc39fa1fe40e815e83a1b2308237d4b7c4fb428174e4d4494cd167e1d0a7c737af0d87987198a9
         x-checker-data:
           type: json
-          url: https://api.adoptium.net/v3/assets/latest/22/hotspot?os=linux&architecture=x64&image_type=jdk
+          url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=x64&image_type=jdk
           version-query: .[0].release_name
-          url-query: '"https://github.com/openjdk/jdk22u/archive/refs/tags/" + $version
+          url-query: '"https://github.com/openjdk/jdk/archive/refs/tags/" + $version
             + ".tar.gz"'
           is-main-source: true
       - type: shell
         commands:
           - chmod a+x configure
-          - sed -i -e "s|@prefix@|$FLATPAK_DEST|" make/autoconf/spec.gmk.in
+          - sed -i -e "s|@prefix@|$FLATPAK_DEST|" make/autoconf/spec.gmk.template
   - name: cacerts
     buildsystem: simple
     sources:
       - type: file
         path: extract_cacerts.sh
     build-commands:
-      - ./extract_cacerts.sh $FLATPAK_DEST/jvm/openjdk-22
+      - ./extract_cacerts.sh $FLATPAK_DEST/jvm/openjdk-23
   - name: ant
     buildsystem: simple
     cleanup:
@@ -169,7 +169,7 @@ modules:
       - type: script
         commands:
           - mkdir -p /app/jre/bin
-          - cd /usr/lib/sdk/openjdk/jvm/openjdk-22
+          - cd /usr/lib/sdk/openjdk/jvm/openjdk-23
           - cp -ra conf lib release /app/jre/
           - rm /app/jre/lib/src.zip /app/jre/lib/ct.sym
           - cp -ra bin/{java,keytool,rmiregistry} /app/jre/bin
@@ -177,12 +177,12 @@ modules:
       - type: script
         commands:
           - mkdir -p /app/jdk/
-          - cd /usr/lib/sdk/openjdk/jvm/openjdk-22
+          - cd /usr/lib/sdk/openjdk/jvm/openjdk-23
           - cp -ra bin conf include jmods lib release /app/jdk/
         dest-filename: installjdk.sh
       - type: script
         commands:
-          - export JAVA_HOME=/usr/lib/sdk/openjdk/jvm/openjdk-22
+          - export JAVA_HOME=/usr/lib/sdk/openjdk/jvm/openjdk-23
           - export PATH=$PATH:/usr/lib/sdk/openjdk/bin
         dest-filename: enable.sh
     build-commands:

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -23,9 +23,9 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23%2B37/OpenJDK23U-jdk_x64_linux_hotspot_23_37.tar.gz
+        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.1%2B11/OpenJDK23U-jdk_x64_linux_hotspot_23.0.1_11.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 99bcd5081a17a533075ccec654d3013f0a212ca33a321c04a9ce95bc51c4094d0d4493b75b30774bffe5c188c419b61d8d6c8fdd62e253f603a93848076ce9b9
+        sha512: bcfc8ea1d835afcfbafc9f99c9e897588bf01e219dda936a4bda7e4982ff0b2cc2f21f5e3deadb0e1cf86a9a58295a25f8f82f9fadd2eab520817350a6a862c1
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -34,9 +34,9 @@ modules:
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23%2B37/OpenJDK23U-jdk_aarch64_linux_hotspot_23_37.tar.gz
+        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.1%2B11/OpenJDK23U-jdk_aarch64_linux_hotspot_23.0.1_11.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: deaff10db582fddad086bb20617206994af78a0bb828e5b15f2d2443f39bcf2bb37fca573654819f23cff8eedb7d9ca7c9e74badf7224cce0d17bd0ba3c35245
+        sha512: 2bc1d9e3a2741e1359915a2479b6f09a3877a6fbb9e358e01e0e5305585c3b974a7847da08857692bc2a65e9dadc77b443739ad1d963941ded37ea97ab8329a0
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=aarch64&image_type=jdk
@@ -52,7 +52,7 @@ modules:
     config-opts:
       - --with-boot-jdk=/usr/lib/sdk/openjdk/bootstrap-java
       - --with-jvm-variants=server
-      - --with-version-build=37
+      - --with-version-build=11
       - --with-version-pre=
       - --with-version-opt=
       - --with-vendor-version-string=24.9
@@ -85,13 +85,13 @@ modules:
       - ln -s $FLATPAK_DEST/jvm/openjdk-23/bin/* $FLATPAK_DEST/bin
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk/archive/refs/tags/jdk-23+37.tar.gz
-        sha512: 169ea4baec06601ce060eb69d9854ffb664a4a26ce69f35886bc39fa1fe40e815e83a1b2308237d4b7c4fb428174e4d4494cd167e1d0a7c737af0d87987198a9
+        url: https://github.com/openjdk/jdk23u/archive/refs/tags/jdk-23.0.1+11.tar.gz
+        sha512: 089c4a8d40fc310b85597aae6fae66951b52a3995602a444e43b173acf7289382fb362b51e53c19466983101d9cbb197922592d720b02f95cedb945adaaccb91
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=x64&image_type=jdk
           version-query: .[0].release_name
-          url-query: '"https://github.com/openjdk/jdk/archive/refs/tags/" + $version
+          url-query: '"https://github.com/openjdk/jdk23u/archive/refs/tags/" + $version
             + ".tar.gz"'
           is-main-source: true
       - type: shell

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -112,9 +112,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.14-bin.tar.gz
+        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.15-bin.tar.gz
         dest-filename: apache-ant-bin.tar.gz
-        sha512: 4e74b382dd8271f9eac9fef69ba94751fb8a8356dbd995c4d642f2dad33de77bd37d4001d6c8f4f0ef6789529754968f0c1b6376668033c8904c6ec84543332a
+        sha512: d78427aff207592c024ff1552dc04f7b57065a195c42d398fcffe7a0145e8d00cd46786f5aa52e77ab0fdf81334f065eb8011eecd2b48f7228e97ff4cb20d16c
         x-checker-data:
           type: anitya
           project-id: 50
@@ -131,9 +131,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: 7d171def9b85846bf757a2cec94b7529371068a0670df14682447224e57983528e97a6d1b850327e4ca02b139abaab7fcb93c4315119e6f0ffb3f0cbc0d0b9a2
+        sha512: a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -150,9 +150,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.10-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.10.2-bin.zip
         dest-filename: gradle-bin.zip
-        sha512: 1d54e3a9067e6caf50bdd50fad8a26a5d64bcfb30e216a93890690a1e749c6a0a624a2250e1afb854d44662f6b37176348b1c26085b4e7124dd8f7ae1fae3769
+        sha512: c48d4b7f4a7b6aa4886848ce913b099b8b7f2494b3d0ca86a21588f6482a185265fffeb0bb6da5f52b8c5f958e589d3a8be9c7fd846790ffbe12be1ad05c9f4f
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -98,6 +98,9 @@ modules:
         commands:
           - chmod a+x configure
           - sed -i -e "s|@prefix@|$FLATPAK_DEST|" make/autoconf/spec.gmk.template
+      - type: patch
+        paths:
+          - patches/0001-Allow-ccache-to-be-handled-by-GCC-wrappers.patch
   - name: cacerts
     buildsystem: simple
     sources:

--- a/org.freedesktop.Sdk.Extension.openjdk.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk.yaml
@@ -23,9 +23,9 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.1%2B11/OpenJDK23U-jdk_x64_linux_hotspot_23.0.1_11.tar.gz
+        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_x64_linux_hotspot_23.0.2_7.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: bcfc8ea1d835afcfbafc9f99c9e897588bf01e219dda936a4bda7e4982ff0b2cc2f21f5e3deadb0e1cf86a9a58295a25f8f82f9fadd2eab520817350a6a862c1
+        sha512: cd3f0f1f5ae97286895d1c243a86193fe31791652bd780d5bfc6062b4421f7111da9fe6ae91071a06aa928626ab710693b3cf6b12a6c9b5f1f9e2148b67c9540
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -34,9 +34,9 @@ modules:
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.1%2B11/OpenJDK23U-jdk_aarch64_linux_hotspot_23.0.1_11.tar.gz
+        url: https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_aarch64_linux_hotspot_23.0.2_7.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 2bc1d9e3a2741e1359915a2479b6f09a3877a6fbb9e358e01e0e5305585c3b974a7847da08857692bc2a65e9dadc77b443739ad1d963941ded37ea97ab8329a0
+        sha512: 70e0a4f040689587da8757821d1ada3b5dc6ac407a336c39f458f91c960f3cb744bb05eb7a6d71885d5d014034c1f5fd5c56c5f2bdd8497e4d22ad353c95afc7
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=aarch64&image_type=jdk
@@ -52,7 +52,7 @@ modules:
     config-opts:
       - --with-boot-jdk=/usr/lib/sdk/openjdk/bootstrap-java
       - --with-jvm-variants=server
-      - --with-version-build=11
+      - --with-version-build=7
       - --with-version-pre=
       - --with-version-opt=
       - --with-vendor-version-string=24.9
@@ -85,8 +85,8 @@ modules:
       - ln -s $FLATPAK_DEST/jvm/openjdk-23/bin/* $FLATPAK_DEST/bin
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk23u/archive/refs/tags/jdk-23.0.1+11.tar.gz
-        sha512: 089c4a8d40fc310b85597aae6fae66951b52a3995602a444e43b173acf7289382fb362b51e53c19466983101d9cbb197922592d720b02f95cedb945adaaccb91
+        url: https://github.com/openjdk/jdk23u/archive/refs/tags/jdk-23.0.2+7.tar.gz
+        sha512: e96abf66cd62c307f71c3a70367a9147e250d84f69c685bfef97f901a5414e1bb10c4702d81238554443b580e654ded41d476643f7649beafa0f3dd98ac4e499
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/23/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -150,9 +150,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.12.1-bin.zip
         dest-filename: gradle-bin.zip
-        sha512: c48d4b7f4a7b6aa4886848ce913b099b8b7f2494b3d0ca86a21588f6482a185265fffeb0bb6da5f52b8c5f958e589d3a8be9c7fd846790ffbe12be1ad05c9f4f
+        sha512: 816d90f7af71f83fbf21b1216c4cdbd64814b109815dfef2a0adced19c598877c781e078ec01f86bfbb830b1dee07483642b5872cdf5a380c0c7da0a8a3a884a
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases

--- a/patches/0001-Allow-ccache-to-be-handled-by-GCC-wrappers.patch
+++ b/patches/0001-Allow-ccache-to-be-handled-by-GCC-wrappers.patch
@@ -1,0 +1,52 @@
+From 896a90d632f0305c8a561664c9348561cef34253 Mon Sep 17 00:00:00 2001
+From: guihkx <626206+guihkx@users.noreply.github.com>
+Date: Tue, 15 Jul 2025 17:23:58 -0300
+Subject: [PATCH] Allow ccache to be handled by GCC wrappers
+
+This allows flatpak-builder not to fail at the configure step when
+invoked with the --ccache option:
+
+===
+$ flatpak run org.flatpak.Builder -v --install-deps-from flathub \
+    --arch x86_64 --delete-build-dirs --force-clean --repo repo/ \
+    --sandbox --ccache builddir/ org.freedesktop.Sdk.Extension.openjdk.yaml
+[...]
+checking for gcc... /run/ccache/bin/gcc
+checking resolved symbolic links for CC... /usr/bin/ccache
+configure: Please use --enable-ccache instead of providing a wrapped compiler.
+configure: error: /run/ccache/bin/gcc is a symbolic link to ccache. This is not supported.
+configure exiting with result code 1
+FB: host_command_exited_cb 8189 256
+
+Error: module java: Child process exited with code 1
+===
+
+This patch is required because Flathub builders use --ccache now:
+
+https://github.com/flathub-infra/vorarbeiter/blob/7f2f04a562e73ba4f46044dae7c99f8e9e64a39d/justfile#L181
+---
+ make/autoconf/toolchain.m4 | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/make/autoconf/toolchain.m4 b/make/autoconf/toolchain.m4
+index e0b4152b81c..e3a99a7512b 100644
+--- a/make/autoconf/toolchain.m4
++++ b/make/autoconf/toolchain.m4
+@@ -478,14 +478,6 @@ AC_DEFUN([TOOLCHAIN_FIND_COMPILER],
+     AC_MSG_RESULT([no symlink])
+   else
+     AC_MSG_RESULT([$SYMLINK_ORIGINAL])
+-
+-    # We can't handle ccache by gcc wrappers, since we need to know if we're
+-    # using ccache. Instead ccache usage must be controlled by a configure option.
+-    COMPILER_BASENAME=`$BASENAME "$SYMLINK_ORIGINAL"`
+-    if test "x$COMPILER_BASENAME" = "xccache"; then
+-      AC_MSG_NOTICE([Please use --enable-ccache instead of providing a wrapped compiler.])
+-      AC_MSG_ERROR([$TEST_COMPILER is a symbolic link to ccache. This is not supported.])
+-    fi
+   fi
+ 
+   TOOLCHAIN_EXTRACT_COMPILER_VERSION([$1], [$COMPILER_NAME])
+-- 
+2.50.1
+


### PR DESCRIPTION
This allows `flatpak-builder` not to fail at the configure step when invoked with the `--ccache` option:

```
$ flatpak run org.flatpak.Builder -v --install-deps-from flathub \
    --arch x86_64 --delete-build-dirs --force-clean --repo repo/ \
    --sandbox --ccache builddir/ org.freedesktop.Sdk.Extension.openjdk.yaml
[...]
checking for gcc... /run/ccache/bin/gcc
checking resolved symbolic links for CC... /usr/bin/ccache
configure: Please use --enable-ccache instead of providing a wrapped compiler.
configure: error: /run/ccache/bin/gcc is a symbolic link to ccache. This is not supported.
configure exiting with result code 1
FB: host_command_exited_cb 8189 256

Error: module java: Child process exited with code 1
```

This patch is required because [Flathub builders use `--ccache` now](https://github.com/flathub-infra/vorarbeiter/blob/7f2f04a562e73ba4f46044dae7c99f8e9e64a39d/justfile#L181).

(cherry picked from commit 64a4bcede1b97552b69ab826ed8a9d7f8bb5d2f9)

---

I've also cherry-picked most commits of `branch/24.08` onto `branch/23.08`, as the 23.08 runtime is still supported (just for one more month, though).